### PR TITLE
Append a reference to the original object

### DIFF
--- a/core-list.html
+++ b/core-list.html
@@ -29,8 +29,8 @@ For performance reasons, not every item in the list is rendered at once.
 @group Polymer Core Elements
 @element core-list
 -->
-<link rel="import" href="bower_components/polymer/polymer.html">
-<link rel="import" href="bower_components/core-selection/core-selection.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../core-selection/core-selection.html">
 
 <polymer-element name="core-list" on-tap="{{tapHandler}}">
 <template>

--- a/core-list.html
+++ b/core-list.html
@@ -29,8 +29,8 @@ For performance reasons, not every item in the list is rendered at once.
 @group Polymer Core Elements
 @element core-list
 -->
-<link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../core-selection/core-selection.html">
+<link rel="import" href="bower_components/polymer/polymer.html">
+<link rel="import" href="bower_components/core-selection/core-selection.html">
 
 <polymer-element name="core-list" on-tap="{{tapHandler}}">
 <template>
@@ -213,6 +213,9 @@ For performance reasons, not every item in the list is rendered at once.
         var propertyName = this._propertyNames[i];
         dest[propertyName] = source[propertyName];
       }
+
+      // add reference to the original model
+      dest._ = source;
     },
 
     // experimental: push physical data back to this.data.


### PR DESCRIPTION
data changes are not detected since `core-list` is cloning the original data and using it as the model of the template.

This pull request suggest a reference to the original data, so We can bind original properties to the template using an underscore like in the example.

Example:

``` html
<core-list data="{{data}}" height="80">
  <template>
    <div class="item {{ {selected: selected} | tokenList }}"> {{_.name}} <br /> 
      <p><i>{{_.description}}</i></p> 
    </div>
  </template>
</core-list>
```

With this approach template is binding the original properties and can detect changes.
