### PR TITLE
Remove spurious repaints in core-list

### DIFF
--- a/core-list.css
+++ b/core-list.css
@@ -1,9 +1,6 @@
 :host {
   display: block;
   overflow: auto;
-  /*-webkit-overflow-scrolling: touch;
-  -webkit-transform: translateZ(0);
-  transform: translateZ(0);*/
 }
 
 .core-list-viewport > * {
@@ -17,4 +14,11 @@
 
 .core-list-viewport.horizontal > * {
   display: inline-block;
+}
+
+/* Setting will-change: transform on the #viewport makes the viewport a
+   stacking context, which causes all the composited layers inside the
+   viewport to actually be stacked underneath the viewport. */
+#viewport {
+  will-change: transform;
 }

--- a/core-list.html
+++ b/core-list.html
@@ -387,12 +387,12 @@ For performance reasons, not every item in the list is rendered at once.
 
   // determine proper transform mechanizm
   if (document.documentElement.style.transform !== undefined) {
-    function setTransform(element, string, value) {
+    var setTransform = function(element, string, value) {
       element.style.transform = string;
       element._transformValue = value;
     }
   } else {
-    function setTransform(element, string, value) {
+    var setTransform = function(element, string, value) {
       element.style.webkitTransform = string;
       element._transformValue = value;
     }


### PR DESCRIPTION
Previously, the core-list viewport was not a stacking context, which meant that
Chrome wouldn't parent the composited layers for the list items underneath the
viewport. Now that the viewport is a stacking context, we get a more sensible
compositing tree, which allows the browser to optimize away the viewport
repaint.

Also, this CL fixes the feature detection for unprefixed transforms.
Previously, we tried to declare a function depending on a runtime value, but,
in JavaScript, function declarations are hoisted to the enclosing scope at
parse time, which means we'd always declare the prefixed version of the
setTransform function. Now we use variable assignment instead, which works.
