### PR TITLE
Use translate instead of translate3d to avoid text blurring

### DIFF
--- a/core-list.html
+++ b/core-list.html
@@ -1058,7 +1058,7 @@ the following abstract API:
               divider.style.width = this.width * this._rowFactor + 'px';
             }
             divider.style.transform = divider.style.webkitTransform =
-              'translate3d(' + x + 'px,' + y + 'px,0)';
+              'translate(' + x + 'px,' + y + 'px)';
             divider._translateX = x;
             divider._translateY = y;
           }
@@ -1068,7 +1068,7 @@ the following abstract API:
         if (physicalItem._translateX != x || physicalItem._translateY != y) {
           physicalItem.style.opacity = 1;
           physicalItem.style.transform = physicalItem.style.webkitTransform =
-            'translate3d(' + x + 'px,' + y + 'px,0)';
+            'translate(' + x + 'px,' + y + 'px)';
           physicalItem._translateX = x;
           physicalItem._translateY = y;
         }


### PR DESCRIPTION
core-list currently uses the translate3d transform to position items, but use of this transform is [known to blur text](http://stackoverflow.com/questions/24860174/webkit-translate3d-makes-my-text-blurred). In trying to adopt the use of core-list to speed up Component Kitchen's main [component catalog page](http://component.kitchen/components), we're seeing this text blurring problem in both Chrome and WebKit.

Here's a snapshot taken in Chrome comparing [normal text](https://drive.google.com/file/d/0B0qD1pAM8eYlb0o4c2hETm9EY2c/view) and the same [text blurred by translate3d](https://drive.google.com/file/d/0B0qD1pAM8eYlQWRnWTBocW1vbnM/view?usp=sharing) when trying to use core-list. It's likely that font and color choices determine the degree of blurring.

This PR replaces use of translate3d with the simpler translate transform. (The core-list code was never setting the translate's Z parameter.) This fixes the problem in Chrome and WebKit. I've checked the core-list project's own demo in Chrome, Safari, Firefox, and IE 11, and don't see any regressions.